### PR TITLE
Add conversation creation routes and document token auth

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -17,10 +17,30 @@
   # SQLite mounted file
   SQLITE_FILE=sqlite:////data/sqlite.db
 
-### Search
+## Auth
 
-- List conversations (search in titles and messages):
-  GET /conversations?search=<term>
+Create a user and obtain an API token:
 
-- List messages in one conversation (search in messages):
-  GET /conversations/{conversation_id}/messages?search=<term>
+- `POST /auth/signup` – create a new user
+- `POST /auth/login` – obtain a token for an existing user
+
+Include the token on all other requests via the `Authorization` header:
+
+```
+Authorization: Bearer <token>
+```
+
+## Conversations API
+
+- `POST /conversations` – create a conversation
+- `GET /conversations` – list conversations (optional `search` and `include_archived`)
+- `GET /conversations/{conversation_id}` – get conversation with messages
+- `PATCH /conversations/{conversation_id}` – update title or archived state
+- `DELETE /conversations/{conversation_id}` – delete conversation
+- `GET /conversations/{conversation_id}/messages` – list messages (optional `search`)
+- `POST /conversations/{conversation_id}/messages` – add message
+- `PATCH /conversations/{conversation_id}/messages/{message_id}` – edit message
+
+## OpenAI-Compatible Routes
+
+Standard OpenAI-style endpoints are available under `/v1/*` and require the token header.

--- a/app/routers/conversations.py
+++ b/app/routers/conversations.py
@@ -1,15 +1,32 @@
-from fastapi import APIRouter, Depends, HTTPException, Request, Query
-from sqlalchemy.orm import Session
-from sqlalchemy import or_
-from sqlalchemy.orm import joinedload
+from datetime import datetime
 from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Security
+from fastapi.security import HTTPBearer
+from sqlalchemy import or_
+from sqlalchemy.orm import Session, joinedload
+
 from ..db import get_db
 from ..models import Conversation, Message
-from ..schemas import ConversationCreate, ConversationOut, ConversationWithMessages, MessageCreate, MessageOut, ConversationUpdate, MessageUpdate
-from datetime import datetime
+from ..schemas import (
+    ConversationCreate,
+    ConversationOut,
+    ConversationUpdate,
+    ConversationWithMessages,
+    MessageCreate,
+    MessageOut,
+    MessageUpdate,
+)
 
 
-router = APIRouter(prefix="/conversations", tags=["conversations"])
+bearer_scheme = HTTPBearer()
+
+router = APIRouter(
+    prefix="/conversations",
+    tags=["conversations"],
+    dependencies=[Security(bearer_scheme)],
+)
+
 
 def _require_user(request: Request) -> str:
     uid = getattr(request.state, "user_id", None)
@@ -17,15 +34,36 @@ def _require_user(request: Request) -> str:
         raise HTTPException(status_code=401, detail="User API key required")
     return uid
 
-from sqlalchemy import or_
-from sqlalchemy.orm import joinedload
 
-@router.get("", response_model=List[ConversationOut], summary="List conversations", description="Optional `search` matches title or any message content.")
+@router.post("", response_model=ConversationOut, summary="Create conversation")
+def create_conversation(
+    payload: ConversationCreate,
+    request: Request,
+    db: Session = Depends(get_db),
+):
+    user_id = _require_user(request)
+    convo = Conversation(title=payload.title, user_id=user_id)
+    db.add(convo)
+    db.commit()
+    db.refresh(convo)
+    return convo
+
+
+@router.get(
+    "",
+    response_model=List[ConversationOut],
+    summary="List conversations",
+    description="Optional `search` matches title or any message content.",
+)
 def list_conversations(
     request: Request,
     db: Session = Depends(get_db),
-    search: str | None = Query(default=None, description="Search in conversation title and messages"),
-    include_archived: bool = Query(default=False, description="Include archived conversations"),
+    search: str | None = Query(
+        default=None, description="Search in conversation title and messages"
+    ),
+    include_archived: bool = Query(
+        default=False, description="Include archived conversations"
+    ),
 ):
     user_id = _require_user(request)
     q = (
@@ -48,20 +86,42 @@ def list_conversations(
 
 
 @router.get("/{conversation_id}", response_model=ConversationWithMessages)
-def get_conversation(conversation_id: str, request: Request, db: Session = Depends(get_db)):
+def get_conversation(
+    conversation_id: str, request: Request, db: Session = Depends(get_db)
+):
     user_id = _require_user(request)
-    convo = db.query(Conversation).filter(Conversation.id == conversation_id, Conversation.user_id == user_id).first()
-    if not convo: raise HTTPException(status_code=404, detail="Conversation not found")
+    convo = (
+        db.query(Conversation)
+        .filter(Conversation.id == conversation_id, Conversation.user_id == user_id)
+        .first()
+    )
+    if not convo:
+        raise HTTPException(status_code=404, detail="Conversation not found")
     return convo
 
-@router.delete("/{conversation_id}", status_code=204)
-def delete_conversation(conversation_id: str, request: Request, db: Session = Depends(get_db)):
-    user_id = _require_user(request)
-    convo = db.query(Conversation).filter(Conversation.id == conversation_id, Conversation.user_id == user_id).first()
-    if not convo: raise HTTPException(status_code=404, detail="Conversation not found")
-    db.delete(convo); db.commit(); return
 
-@router.patch("/{conversation_id}", response_model=ConversationOut, summary="Update conversation (title / archived)")
+@router.delete("/{conversation_id}", status_code=204)
+def delete_conversation(
+    conversation_id: str, request: Request, db: Session = Depends(get_db)
+):
+    user_id = _require_user(request)
+    convo = (
+        db.query(Conversation)
+        .filter(Conversation.id == conversation_id, Conversation.user_id == user_id)
+        .first()
+    )
+    if not convo:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    db.delete(convo)
+    db.commit()
+    return
+
+
+@router.patch(
+    "/{conversation_id}",
+    response_model=ConversationOut,
+    summary="Update conversation (title / archived)",
+)
 def update_conversation(
     conversation_id: str,
     payload: ConversationUpdate,
@@ -83,15 +143,22 @@ def update_conversation(
         convo.archived = bool(payload.archived)
         convo.archived_at = datetime.utcnow() if convo.archived else None
 
-    db.commit(); db.refresh(convo)
+    db.commit()
+    db.refresh(convo)
     return convo
 
-@router.get("/{conversation_id}/messages", response_model=List[MessageOut], summary="List messages in a conversation", description="Optional `search` matches message content.")
+
+@router.get(
+    "/{conversation_id}/messages",
+    response_model=List[MessageOut],
+    summary="List messages in a conversation",
+    description="Optional `search` matches message content.",
+)
 def list_messages(
     conversation_id: str,
     request: Request,
     db: Session = Depends(get_db),
-    search: str | None = Query(default=None, description="Search in message content")
+    search: str | None = Query(default=None, description="Search in message content"),
 ):
     user_id = _require_user(request)
     convo = (
@@ -102,7 +169,11 @@ def list_messages(
     if not convo:
         raise HTTPException(status_code=404, detail="Conversation not found")
 
-    q = db.query(Message).filter(Message.conversation_id == conversation_id).order_by(Message.created_at.asc())
+    q = (
+        db.query(Message)
+        .filter(Message.conversation_id == conversation_id)
+        .order_by(Message.created_at.asc())
+    )
 
     if search:
         like = f"%{search}%"
@@ -111,15 +182,37 @@ def list_messages(
     return q.all()
 
 
-@router.get("/{conversation_id}/messages", response_model=List[MessageOut])
-def list_messages(conversation_id: str, request: Request, db: Session = Depends(get_db)):
+@router.post(
+    "/{conversation_id}/messages",
+    response_model=MessageOut,
+    summary="Add message to conversation",
+)
+def add_message(
+    conversation_id: str,
+    body: MessageCreate,
+    request: Request,
+    db: Session = Depends(get_db),
+):
     user_id = _require_user(request)
-    convo = db.query(Conversation).filter(Conversation.id == conversation_id, Conversation.user_id == user_id).first()
-    if not convo: raise HTTPException(status_code=404, detail="Conversation not found")
-    return convo.messages
+    convo = (
+        db.query(Conversation)
+        .filter(Conversation.id == conversation_id, Conversation.user_id == user_id)
+        .first()
+    )
+    if not convo:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    msg = Message(conversation_id=conversation_id, role=body.role, content=body.content)
+    db.add(msg)
+    db.commit()
+    db.refresh(msg)
+    return msg
 
 
-@router.patch("/{conversation_id}/messages/{message_id}", response_model=MessageOut, summary="Edit a message")
+@router.patch(
+    "/{conversation_id}/messages/{message_id}",
+    response_model=MessageOut,
+    summary="Edit a message",
+)
 def edit_message(
     conversation_id: str,
     message_id: str,
@@ -145,5 +238,7 @@ def edit_message(
         raise HTTPException(status_code=404, detail="Message not found")
 
     msg.content = body.content
-    db.commit(); db.refresh(msg)
+    db.commit()
+    db.refresh(msg)
     return msg
+


### PR DESCRIPTION
## Summary
- add POST /conversations and /conversations/{id}/messages endpoints
- fix chat completion request handling and document bearer auth across routes
- document auth routes and token usage in README

## Testing
- `python -m py_compile app/routers/conversations.py app/routers/openai_proxy.py app/routers/users.py app/main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898106d7ebc8321847ac8dc032206c0