### PR TITLE
Add file upload and attachment support

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,7 @@ from .auth import auth_middleware
 from .db import engine, Base
 from fastapi.middleware.cors import CORSMiddleware
 from .settings import APP_NAME, APP_VERSION, CORS_ORIGINS
-from .routers import openai_proxy, conversations, users
+from .routers import openai_proxy, conversations, users, files
 
 app = FastAPI(title=APP_NAME, version=APP_VERSION)
 
@@ -24,3 +24,4 @@ app.middleware("http")(auth_middleware)
 app.include_router(users.router)
 app.include_router(openai_proxy.router)
 app.include_router(conversations.router)
+app.include_router(files.router)

--- a/app/migrations/versions/0003_files.py
+++ b/app/migrations/versions/0003_files.py
@@ -1,0 +1,37 @@
+"""add files and message_files tables
+
+Revision ID: 0003_files
+Revises: 0002_archive_fields
+Create Date: 2025-08-10
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0003_files"
+down_revision = "0002_archive_fields"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "files",
+        sa.Column("id", sa.String(length=32), primary_key=True),
+        sa.Column("mime_type", sa.String(length=255), nullable=False),
+        sa.Column("size", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("path", sa.String(length=1024), nullable=False),
+        sa.Column("owner", sa.String(length=32), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("upload_date", sa.DateTime(timezone=False), server_default=sa.func.now(), nullable=False),
+    )
+
+    op.create_table(
+        "message_files",
+        sa.Column("message_id", sa.String(length=32), sa.ForeignKey("messages.id", ondelete="CASCADE"), primary_key=True),
+        sa.Column("file_id", sa.String(length=32), sa.ForeignKey("files.id", ondelete="CASCADE"), primary_key=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("message_files")
+    op.drop_table("files")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -2,5 +2,6 @@
 from .user import User
 from .conversation import Conversation
 from .message import Message
+from .file import File
 
-__all__ = ["User", "Conversation", "Message"]
+__all__ = ["User", "Conversation", "Message", "File"]

--- a/app/models/file.py
+++ b/app/models/file.py
@@ -1,0 +1,48 @@
+import uuid
+from sqlalchemy import (
+    String,
+    DateTime,
+    func,
+    ForeignKey,
+    Integer,
+    Table,
+    Column,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from ..db import Base
+
+
+def _uuid() -> str:
+    return uuid.uuid4().hex
+
+
+message_files = Table(
+    "message_files",
+    Base.metadata,
+    Column("message_id", String(32), ForeignKey("messages.id", ondelete="CASCADE"), primary_key=True),
+    Column("file_id", String(32), ForeignKey("files.id", ondelete="CASCADE"), primary_key=True),
+)
+
+
+class File(Base):
+    __tablename__ = "files"
+
+    id: Mapped[str] = mapped_column(String(32), primary_key=True, default=_uuid)
+    mime_type: Mapped[str] = mapped_column(String(255), nullable=False)
+    size: Mapped[int] = mapped_column(Integer, nullable=False)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    path: Mapped[str] = mapped_column(String(1024), nullable=False)
+    owner: Mapped[str] = mapped_column(String(32), ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    upload_date: Mapped[str] = mapped_column(DateTime(timezone=False), server_default=func.now(), nullable=False)
+
+    messages: Mapped[list["Message"]] = relationship(
+        "Message", secondary=message_files, back_populates="files"
+    )
+
+    @property
+    def public_url(self) -> str:
+        """Return a publicly accessible URL for this file."""
+        from ..services import file_service
+
+        return file_service.public_url(self.path)

--- a/app/models/message.py
+++ b/app/models/message.py
@@ -2,6 +2,7 @@ import uuid
 from sqlalchemy import String, Text, DateTime, func, ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from ..db import Base
+from .file import message_files
 
 def _uuid() -> str:
     return uuid.uuid4().hex
@@ -16,3 +17,6 @@ class Message(Base):
     created_at: Mapped[str] = mapped_column(DateTime(timezone=False), server_default=func.now(), nullable=False)
 
     conversation: Mapped["Conversation"] = relationship("Conversation", back_populates="messages")
+    files: Mapped[list["File"]] = relationship(
+        "File", secondary=message_files, back_populates="messages"
+    )

--- a/app/routers/files.py
+++ b/app/routers/files.py
@@ -1,0 +1,53 @@
+from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile, File as FastAPIFile, Security, Response
+from fastapi.security import HTTPBearer
+from sqlalchemy.orm import Session
+
+from ..db import get_db
+from ..schemas import FileOut
+from ..settings import FILE_ALLOWED_MIME_TYPES, FILE_MAX_SIZE
+from ..services import file_service
+
+bearer_scheme = HTTPBearer()
+
+router = APIRouter(
+    prefix="/files",
+    tags=["files"],
+    dependencies=[Security(bearer_scheme)],
+)
+
+
+def _require_user(request: Request) -> str:
+    uid = getattr(request.state, "user_id", None)
+    if uid is None:
+        raise HTTPException(status_code=401, detail="User API key required")
+    return uid
+
+
+@router.post("/upload", response_model=FileOut, summary="Upload a file")
+async def upload_file(
+    request: Request,
+    upload: UploadFile = FastAPIFile(...),
+    db: Session = Depends(get_db),
+):
+    user_id = _require_user(request)
+    if FILE_ALLOWED_MIME_TYPES and upload.content_type not in FILE_ALLOWED_MIME_TYPES:
+        raise HTTPException(status_code=400, detail="File type not allowed")
+
+    data = await upload.read()
+    if len(data) > FILE_MAX_SIZE:
+        raise HTTPException(status_code=400, detail="File too large")
+    return file_service.upload(upload, data, user_id, db)
+
+
+@router.delete("/{file_id}", status_code=204, summary="Delete a file")
+def delete_file(
+    file_id: str,
+    request: Request,
+    db: Session = Depends(get_db),
+):
+    user_id = _require_user(request)
+    file_obj = file_service.get(db, file_id, user_id)
+    if not file_obj:
+        raise HTTPException(status_code=404, detail="File not found")
+    file_service.delete(db, file_obj)
+    return Response(status_code=204)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,46 +1,81 @@
-from pydantic import BaseModel, Field
+from datetime import datetime
 from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
 
 class UserCreate(BaseModel):
     username: str
     password: str
 
+
 class LoginRequest(BaseModel):
     username: str
     password: str
 
+
 class LoginResponse(BaseModel):
     api_key: str
 
+
 class ConversationCreate(BaseModel):
     title: Optional[str] = None
+
 
 class ConversationUpdate(BaseModel):
     title: Optional[str] = None
     archived: Optional[bool] = None
 
+
 class ConversationOut(BaseModel):
     id: str
     title: Optional[str] = None
     archived: bool = False
-    class Config: from_attributes = True
+
+    class Config:
+        from_attributes = True
+
+
+class FileOut(BaseModel):
+    id: str
+    mime_type: str
+    size: int
+    name: str
+    path: str
+    owner: str
+    upload_date: datetime
+    public_url: str
+
+    class Config:
+        from_attributes = True
+
 
 class MessageCreate(BaseModel):
     role: str = Field(..., pattern="^(system|user|assistant|tool)$")
     content: str
+    file_ids: List[str] = []
+
 
 class MessageUpdate(BaseModel):
-    content: str
+    content: Optional[str] = None
+    file_ids: Optional[List[str]] = None
+
 
 class MessageOut(BaseModel):
     id: str
     role: str
     content: str
-    class Config: from_attributes = True
+    files: List[FileOut] = []
+
+    class Config:
+        from_attributes = True
+
 
 class ConversationWithMessages(BaseModel):
     id: str
     title: Optional[str] = None
     archived: bool = False
     messages: List[MessageOut]
-    class Config: from_attributes = True
+
+    class Config:
+        from_attributes = True

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,3 @@
+from .files import file_service, FileService
+
+__all__ = ["file_service", "FileService"]

--- a/app/services/files.py
+++ b/app/services/files.py
@@ -1,0 +1,75 @@
+import os
+import uuid
+from typing import Optional
+
+import fsspec
+import s3fs
+from fastapi import UploadFile
+from sqlalchemy.orm import Session
+
+from ..models import File
+from ..settings import (
+    FILE_STORAGE_BACKEND,
+    FILE_STORAGE_LOCAL_PATH,
+    FILE_STORAGE_S3_BUCKET,
+    FILE_PUBLIC_BASE_URL,
+)
+
+
+class FileService:
+    """Service handling file storage and URL generation."""
+
+    def __init__(self) -> None:
+        if FILE_STORAGE_BACKEND == "s3":
+            self.fs = s3fs.S3FileSystem()
+            self.base = FILE_STORAGE_S3_BUCKET
+        else:
+            self.fs = fsspec.filesystem("file")
+            self.base = FILE_STORAGE_LOCAL_PATH
+            self.fs.makedirs(self.base, exist_ok=True)
+
+    def _full_path(self, path: str) -> str:
+        if FILE_STORAGE_BACKEND == "s3":
+            return f"{self.base}/{path}"
+        return os.path.join(self.base, path)
+
+    def upload(self, upload: UploadFile, data: bytes, owner: str, db: Session) -> File:
+        ext = os.path.splitext(upload.filename)[1]
+        file_id = uuid.uuid4().hex
+        path = f"{file_id}{ext}"
+        dest = self._full_path(path)
+        with self.fs.open(dest, "wb") as f:
+            f.write(data)
+        file_obj = File(
+            id=file_id,
+            mime_type=upload.content_type,
+            size=len(data),
+            name=upload.filename,
+            path=path,
+            owner=owner,
+        )
+        db.add(file_obj)
+        db.commit()
+        db.refresh(file_obj)
+        return file_obj
+
+    def get(self, db: Session, file_id: str, owner: str) -> Optional[File]:
+        return db.query(File).filter(File.id == file_id, File.owner == owner).first()
+
+    def delete(self, db: Session, file_obj: File) -> None:
+        dest = self._full_path(file_obj.path)
+        if self.fs.exists(dest):
+            self.fs.rm(dest)
+        db.delete(file_obj)
+        db.commit()
+
+    def public_url(self, path: str) -> str:
+        if FILE_STORAGE_BACKEND == "s3":
+            return self.fs.url(f"{self.base}/{path}")
+        base = FILE_PUBLIC_BASE_URL.rstrip("/") if FILE_PUBLIC_BASE_URL else ""
+        if base:
+            return f"{base}/{path}"
+        return path
+
+
+file_service = FileService()

--- a/app/settings.py
+++ b/app/settings.py
@@ -32,3 +32,18 @@ DATABASE_URL = os.getenv("DATABASE_URL", "")
 # Server
 APP_NAME = "OpenAI-compatible proxy for Ollama"
 APP_VERSION = "1.1.0"
+
+# Files
+FILE_ALLOWED_MIME_TYPES = {
+    m.strip()
+    for m in os.getenv(
+        "FILE_ALLOWED_MIME_TYPES",
+        "image/png,image/jpeg,application/pdf,text/plain",
+    ).split(",")
+    if m.strip()
+}
+FILE_MAX_SIZE = int(os.getenv("FILE_MAX_SIZE", str(10 * 1024 * 1024)))  # 10MB default
+FILE_STORAGE_BACKEND = os.getenv("FILE_STORAGE_BACKEND", "local")  # 'local' or 's3'
+FILE_STORAGE_LOCAL_PATH = os.getenv("FILE_STORAGE_LOCAL_PATH", "uploads")
+FILE_STORAGE_S3_BUCKET = os.getenv("FILE_STORAGE_S3_BUCKET", "")
+FILE_PUBLIC_BASE_URL = os.getenv("FILE_PUBLIC_BASE_URL", "")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ SQLAlchemy>=2.0
 psycopg2-binary
 alembic
 passlib[bcrypt]
+fsspec
+s3fs


### PR DESCRIPTION
## Summary
- refactor file handling into a dedicated service that abstracts storage and URL generation
- expose `/files/{id}` delete endpoint and remove backend checks from API layer
- compute file `public_url` via the new service

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fsspec)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1522d7e148321b24ec8691af34463